### PR TITLE
Feature/creates output if not found

### DIFF
--- a/figs/scripts/fig_deltalatticeMarkov.R
+++ b/figs/scripts/fig_deltalatticeMarkov.R
@@ -37,7 +37,7 @@ beta <- R0 * (gamma/N)
 tmax <- 5
 
 # mc reps
-nrep <- 50
+nrep <- 2e5
 
 # lattice of time points
 abm_dt <- c(0.001,0.005,0.01,0.025,0.05,0.075,0.1,0.5,1)

--- a/figs/scripts/fig_deltalatticeMarkov.R
+++ b/figs/scripts/fig_deltalatticeMarkov.R
@@ -22,6 +22,11 @@ library(doParallel)
 # cores for parallel
 ncores <- 16
 
+fig_directory <- here::here("/figs")
+if (!dir.exists(fig_directory)) {
+  dir.create(fig_directory)
+}
+
 # parameters
 S0 = 60 # S_0
 I0 = 10 # I_0
@@ -32,7 +37,7 @@ beta <- R0 * (gamma/N)
 tmax <- 5
 
 # mc reps
-nrep <- 2e5
+nrep <- 50
 
 # lattice of time points
 abm_dt <- c(0.001,0.005,0.01,0.025,0.05,0.075,0.1,0.5,1)
@@ -71,7 +76,7 @@ deltaMarkov_ABM <- foreach(i = mc_reps$rep, dt = mc_reps$dt,.combine = "rbind",.
 }
 
 # clean up the parallel cluster and remove it
-close(pb)
 parallel::stopCluster(cl);rm(cl);gc()
-
-saveRDS(object = deltaMarkov_ABM,file = here::here("/figs/deltaMarkov_ABM.rds"),compress = TRUE)
+result_file <- paste(fig_directory, "/deltaMarkov_ABM.rds", sep = "", collapse = "")
+cat(paste("writing to", result_file, "\n"))
+saveRDS(object = deltaMarkov_ABM,file = result_file, compress = TRUE)


### PR DESCRIPTION
When I run from a different directory, the `here` project doesn't find the `figs` directory you wanted. It picks a subdirectory, the one with the Rstudio project, instead. So this makes sure that, no matter what, we get our output.
```
~/dev/euler-abm/stocheulerABM$ Rscript ../figs/scripts/fig_deltalatticeMarkov.R 
         used (Mb) gc trigger (Mb) max used (Mb)
Ncells 406368 21.8     833805 44.6   654491 35.0
Vcells 636641  4.9    8388608 64.0  1797917 13.8
here() starts at /home/adolgert/dev/euler-abm/stocheulerABM
Loading required package: iterators
         used (Mb) gc trigger (Mb) max used (Mb)
Ncells 563250 30.1    1040566 55.6   833805 44.6
Vcells 936349  7.2    8388608 64.0  2364041 18.1
writing to /home/adolgert/dev/euler-abm/stocheulerABM//figs/deltaMarkov_ABM.rds 
```
